### PR TITLE
Add serial_number to UsbDeviceInfo

### DIFF
--- a/src/common.rs
+++ b/src/common.rs
@@ -11,6 +11,8 @@ pub struct UsbDevice {
     pub product_id: u16,
     /// Optional device description
     pub description: Option<String>,
+    /// Optional serial number
+    pub serial_number: Option<String>,
 }
 
 #[derive(Copy, Clone, Debug)]

--- a/src/linux.rs
+++ b/src/linux.rs
@@ -57,11 +57,19 @@ pub fn enumerate_platform(vid: Option<u16>, pid: Option<u16>) -> Vec<UsbDevice> 
                     .map(|s| s.to_string());
             }
 
+            let serial_number = device
+                .property_value("ID_SERIAL_SHORT")
+                .ok_or(ParseError)?
+                .to_str()
+                .ok_or(ParseError)?
+                .to_string();
+
             output.push(UsbDevice {
                 id,
                 vendor_id,
                 product_id,
                 description,
+                serial_number: Some(serial_number),
             });
 
             Ok(())

--- a/src/linux.rs
+++ b/src/linux.rs
@@ -59,17 +59,15 @@ pub fn enumerate_platform(vid: Option<u16>, pid: Option<u16>) -> Vec<UsbDevice> 
 
             let serial_number = device
                 .property_value("ID_SERIAL_SHORT")
-                .ok_or(ParseError)?
-                .to_str()
-                .ok_or(ParseError)?
-                .to_string();
+                .and_then(|s| s.to_str())
+                .map(|s| s.to_string());
 
             output.push(UsbDevice {
                 id,
                 vendor_id,
                 product_id,
                 description,
-                serial_number: Some(serial_number),
+                serial_number,
             });
 
             Ok(())

--- a/src/macos.rs
+++ b/src/macos.rs
@@ -77,11 +77,18 @@ pub fn enumerate_platform(vid: Option<u16>, pid: Option<u16>) -> Vec<UsbDevice> 
                     .and_then(|value_ref| value_ref.downcast::<CFString>())
                     .map(|s| s.to_string());
 
+                let key = CFString::from_static_string("USB Serial Number");
+                let serial_number = properties
+                    .find(&key)
+                    .and_then(|value_ref| value_ref.downcast::<CFString>())
+                    .map(|s| s.to_string());
+
                 output.push(UsbDevice {
                     id: id.to_string(),
                     vendor_id,
                     product_id,
                     description,
+                    serial_number,
                 });
 
                 Ok(())

--- a/src/windows.rs
+++ b/src/windows.rs
@@ -84,13 +84,14 @@ pub fn enumerate_platform(vid: Option<u16>, pid: Option<u16>) -> Vec<UsbDevice> 
                         )
                     } > 0
                     {
-                        let id = string_from_buf_u16(buf);
+                        let id = string_from_buf_u16(buf.clone());
+                        let serial_number = extract_serial_number(buf);
                         output.push(UsbDevice {
                             id,
                             vendor_id,
                             product_id,
                             description: Some(description),
-                            serial_number: None,
+                            serial_number,
                         });
                     }
                 }
@@ -113,6 +114,12 @@ fn extract_vid_pid(buf: Vec<u8>) -> Result<(u16, u16), Box<dyn Error + Send + Sy
         u16::from_str_radix(&id[vid + 4..vid + 8], 16)?,
         u16::from_str_radix(&id[pid + 4..pid + 8], 16)?,
     ))
+}
+
+fn extract_serial_number(buf: Vec<u16>) -> Option<String> {
+    let id = string_from_buf_u16(buf);
+
+    id.split("\\").last().map(|s| s.to_owned())
 }
 
 fn string_from_buf_u16(buf: Vec<u16>) -> String {

--- a/src/windows.rs
+++ b/src/windows.rs
@@ -90,6 +90,7 @@ pub fn enumerate_platform(vid: Option<u16>, pid: Option<u16>) -> Vec<UsbDevice> 
                             vendor_id,
                             product_id,
                             description: Some(description),
+                            serial_number: None,
                         });
                     }
                 }


### PR DESCRIPTION
Adds serial number to `UsbDeviceInfo` structure and it's detection / parsing, now implemented for Linux and macOS.

I've found it useful particularly when testing multiple device instances of same model from a single manufacturer but also can be used as a poor man's solution for getting a device file name on macOS.

I will add Windows implementation as soon as I get my hands on a Windows machine.