### PR TITLE
fix(osx): leaked CFDictionary object allocated by IORegistryEntryCrea…

### DIFF
--- a/src/macos.rs
+++ b/src/macos.rs
@@ -39,6 +39,7 @@ pub fn enumerate_platform(vid: Option<u16>, pid: Option<u16>) -> Vec<UsbDevice> 
 
             let properties: CFDictionary<CFString, CFType> =
                 CFMutableDictionary::wrap_under_get_rule(props).to_immutable();
+            CFRelease(props.as_void_ptr());
 
             let _ = || -> Result<(), Box<dyn Error>> {
                 let key = CFString::from_static_string("idVendor");


### PR DESCRIPTION
[IORegistryEntryCreateCFProperties](https://developer.apple.com/documentation/iokit/1514310-ioregistryentrycreatecfpropertie?language=objc) returns an allocated object which is never released. 

`leaks` reports the following:

```
deb(7603) MallocStackLogging: could not tag MSL-related memory as no_footprint, so those pages will be included in process footprint - (null)
deb(7603) MallocStackLogging: recording malloc (and VM allocation) stacks using lite mode
[
    UsbDevice {
        id: "122613783",
        vendor_id: 1507,
        product_id: 1574,
        description: Some(
            "USB3.1 Hub",
        ),
        serial_number: None,
    },
    UsbDevice {
        id: "127173742",
        vendor_id: 1507,
        product_id: 1552,
        description: Some(
            "USB2.1 Hub",
        ),
        serial_number: None,
    },
    UsbDevice {
        id: "131545291",
        vendor_id: 1133,
        product_id: 49298,
        description: Some(
            "G102 LIGHTSYNC Gaming Mouse",
        ),
        serial_number: Some(
            "207036595943",
        ),
    },
    UsbDevice {
        id: "133227286",
        vendor_id: 12815,
        product_id: 20480,
        description: Some(
            "RGB Keyboard",
        ),
        serial_number: None,
    },
    UsbDevice {
        id: "6282346123",
        vendor_id: 1452,
        product_id: 4363,
        description: Some(
            "EarPods",
        ),
        serial_number: Some(
            "LYFQ41JJRF",
        ),
    },
]
Process:         deb [7603]
Path:            /Users/USER/*/deb
Load Address:    0x100a20000
Identifier:      deb
Version:         0
Code Type:       ARM64
Platform:        macOS
Parent Process:  leaks [7602]

Date/Time:       2024-10-25 12:30:39.438 +0530
Launch Time:     2024-10-25 12:30:39.063 +0530
OS Version:      macOS 15.0.1 (24A348)
Report Version:  7
Analysis Tool:   /Applications/Xcode.app/Contents/Developer/usr/bin/leaks
Analysis Tool Version:  Xcode 16.0 (16A242d)

Physical footprint:         3329K
Physical footprint (peak):  3329K
Idle exit:                  untracked
----

leaks Report Version: 4.0, multi-line stacks
Process 7603: 951 nodes malloced for 79 KB
Process 7603: 203 leaks for 16976 total leaked bytes.

STACK OF 5 INSTANCES OF 'ROOT LEAK: <NSMutableDictionary>':
17  dyld                                  0x184b94274 start + 2840
16  deb                                   0x100a243c0 main + 36
15  deb                                   0x100a23eb0 std::rt::lang_start::he2a1f3d1b064555b + 84  rt.rs:161
14  deb                                   0x100a447e0 std::rt::lang_start_internal::hdd117cb81a316264 + 808
13  deb                                   0x100a23ee4 std::rt::lang_start::_$u7b$$u7b$closure$u7d$$u7d$::hc8f8a7e19ee1dee1 + 28  rt.rs:162
12  deb                                   0x100a2446c std::sys::backtrace::__rust_begin_short_backtrace::h91163a82d44e907f + 24  backtrace.rs:158
11  deb                                   0x100a241c8 core::ops::function::FnOnce::call_once::h1a8019a83cc6174a + 20  function.rs:250
10  deb                                   0x100a24254 deb::main::hfdb9d96ecd3973e7 + 52  main.rs:2
9   deb                                   0x100a256a4 usb_enumeration::enumerate::hfabda9ca37734b91 + 32
8   deb                                   0x100a26300 usb_enumeration::macos::enumerate_platform::h0ee8ea19dc88ff50 + 468
7   com.apple.framework.IOKit             0x1889b99f8 IORegistryEntryCreateCFProperties + 196
6   com.apple.framework.IOKit             0x1889b9eb4 IOCFUnserializeBinary + 412
5   com.apple.CoreFoundation              0x184f855cc CFDictionaryCreateMutable + 44
4   com.apple.CoreFoundation              0x184f862c8 __NSDictionaryM_new + 136
3   com.apple.CoreFoundation              0x184f84858 __CFAllocateObject + 20
2   libobjc.A.dylib                       0x184b43a34 class_createInstance + 72
1   libsystem_malloc.dylib                0x184d3bbc0 _calloc + 88
0   libsystem_malloc.dylib                0x184d4ea84 _malloc_zone_calloc_instrumented_or_legacy + 128
====
    203 (16.6K) << TOTAL >>

      41 (4.03K) ROOT LEAK: <NSMutableDictionary 0x145f0bc40> [48]  item count: 33
         40 (3.98K) <NSMutableDictionary (Storage) 0x14680b400> [1536]
            7 (576 bytes) <NSMutableDictionary 0x145f0be80> [48]  item count: 7
               6 (528 bytes) <NSMutableDictionary (Storage) 0x145f0c530> [224]
                  1 (64 bytes) <CFString 0x145f0beb0> [64]  length: 16  "DevicePowerState"
                  1 (64 bytes) <CFString 0x145f0bef0> [64]  length: 16  "DriverPowerState"
                  1 (64 bytes) <CFString 0x145f0c820> [64]  length: 15  "CapabilityFlags"
                  1 (64 bytes) <CFString 0x145f0c890> [64]  length: 15  "PowerOverrideOn"
                  1 (48 bytes) <CFString 0x145f0c860> [48]  length: 13  "MaxPowerState"
            4 (288 bytes) <NSMutableDictionary 0x145f0cd70> [48]  item count: 1
               3 (240 bytes) <NSMutableDictionary (Storage) 0x145f0cda0> [64]
                  1 (96 bytes) <CFString 0x145f0bcc0> [96]  length: 53  "IOUSBHostFamily.kext/Contents/PlugIns/IOUSBLib.bundle"
                  1 (80 bytes) <CFString 0x145f0bc70> [80]  length: 36  "9dc7b780-9ec0-11d4-a54f-000a27052861"
            5 (272 bytes) <NSMutableArray 0x145f0cc80> [64]  item count: 1
               4 (208 bytes) <NSMutableArray (Storage) 0x145f068d0> [32]
                  3 (176 bytes) <NSMutableArray 0x145f0ccc0> [64]  item count: 1
                     2 (112 bytes) <NSMutableArray (Storage) 0x145f0cd50> [32]
                        1 (80 bytes) <CFString 0x145f0cd00> [80]  length: 43  "com.apple.developer.driverkit.transport.usb"
            1 (128 bytes) <CFData 0x145f0cbc0> [128]  inline content length 34: 0xAC050B1181 "&LYFQ41JJRF" 0xEF0201010120010220030000010130010230
            1 (64 bytes) <CFString 0x145f0bd20> [64]  length: 16  "USB Product Name"
            1 (64 bytes) <CFString 0x145f0bd60> [64]  length: 15  "USB Vendor Name"
            1 (64 bytes) <CFString 0x145f0bda0> [64]  length: 17  "USB Serial Number"
            1 (64 bytes) <CFString 0x145f0c8d0> [64]  length: 15  "bDeviceSubClass"
            1 (64 bytes) <CFString 0x145f0c910> [64]  length: 15  "bDeviceProtocol"
            1 (64 bytes) <CFString 0x145f0c9b0> [64]  length: 15  "bMaxPacketSize0"
            1 (64 bytes) <CFString 0x145f0ca50> [64]  length: 18  "bNumConfigurations"
            1 (64 bytes) <CFString 0x145f0ca90> [64]  length: 17  "kUSBProductString"
            1 (64 bytes) <CFString 0x145f0cad0> [64]  length: 16  "kUSBVendorString"
            1 (64 bytes) <CFString 0x145f0cb10> [64]  length: 22  "kUSBSerialNumberString"
            1 (64 bytes) <CFString 0x145f0cb80> [64]  length: 18  "UsbDeviceSignature"
            1 (64 bytes) <CFString 0x145f0cc40> [64]  length: 25  "IOServiceDEXTEntitlements"
            1 (64 bytes) <CFString 0x145f0cde0> [64]  length: 26  "kUSBPreferredConfiguration"
            1 (64 bytes) <CFString 0x145f0ceb0> [64]  length: 24  "kUSBCurrentConfiguration"
            1 (48 bytes) <CFString 0x145f0bde0> [48]  length: 12  "Device Speed"
            1 (48 bytes) <CFString 0x145f0be10> [48]  length: 11  "USB Address"
            1 (48 bytes) <CFString 0x145f0be40> [48]  length: 14  "DisplayRouting"
            1 (48 bytes) <CFString 0x145f0c950> [48]  length: 11  "USBPortType"
            1 (48 bytes) <CFString 0x145f0c980> [48]  length: 11  "kUSBAddress"
            1 (48 bytes) <CFString 0x145f0c9f0> [48]  length: 13  "iManufacturer"
            1 (48 bytes) <CFString 0x145f0ca20> [48]  length: 13  "iSerialNumber"
            1 (48 bytes) <CFString 0x145f0cb50> [48]  length: 10  "LYFQ41JJRF"

      43 (3.28K) ROOT LEAK: <NSMutableDictionary 0x145f088d0> [48]  item count: 32
         42 (3.23K) <NSMutableDictionary (Storage) 0x145f08d80> [672]
            7 (576 bytes) <NSMutableDictionary 0x145f08a60> [48]  item count: 7
               6 (528 bytes) <NSMutableDictionary (Storage) 0x145f09230> [224]
                  1 (64 bytes) <CFString 0x145f08a20> [64]  length: 16  "DevicePowerState"
                  1 (64 bytes) <CFString 0x145f09520> [64]  length: 16  "DriverPowerState"
                  1 (64 bytes) <CFString 0x145f09560> [64]  length: 15  "CapabilityFlags"
                  1 (64 bytes) <CFString 0x145f095a0> [64]  length: 15  "PowerOverrideOn"
                  1 (48 bytes) <CFString 0x145f08a90> [48]  length: 13  "MaxPowerState"
            4 (288 bytes) <NSMutableDictionary 0x145f09d00> [48]  item count: 1
               3 (240 bytes) <NSMutableDictionary (Storage) 0x145f09d30> [64]
                  1 (96 bytes) <CFString 0x145f09070> [96]  length: 53  "IOUSBHostFamily.kext/Contents/PlugIns/IOUSBLib.bundle"
                  1 (80 bytes) <CFString 0x145f09020> [80]  length: 36  "9dc7b780-9ec0-11d4-a54f-000a27052861"
            5 (272 bytes) <NSMutableArray 0x145f09bd0> [64]  item count: 1
               4 (208 bytes) <NSMutableArray (Storage) 0x145f086a0> [32]
                  3 (176 bytes) <NSMutableArray 0x145f09c40> [64]  item count: 1
                     2 (112 bytes) <NSMutableArray (Storage) 0x145f07000> [32]
                        1 (80 bytes) <CFString 0x145f09cb0> [80]  length: 43  "com.apple.developer.driverkit.transport.usb"
            1 (96 bytes) <CFData 0x145f09a10> [96]  inline content length 12: 0xE30526065606090003090000
            1 (80 bytes) <CFString 0x145f09980> [80]  length: 36  "f0564b9f-f61d-e011-ac64-0800200c9a66"
            1 (64 bytes) <CFString 0x145f090d0> [64]  length: 16  "USB Product Name"
            1 (64 bytes) <CFString 0x145f09110> [64]  length: 15  "USB Vendor Name"
            1 (64 bytes) <CFString 0x145f091b0> [64]  length: 17  "kUSBHubIdlePolicy"
            1 (64 bytes) <CFString 0x145f091f0> [64]  length: 17  "UsbExclusiveOwner"
            1 (64 bytes) <CFString 0x145f095e0> [64]  length: 15  "bDeviceSubClass"
            1 (64 bytes) <CFString 0x145f096b0> [64]  length: 15  "bDeviceProtocol"
            1 (64 bytes) <CFString 0x145f09780> [64]  length: 15  "bMaxPacketSize0"
            1 (64 bytes) <CFString 0x145f09820> [64]  length: 18  "bNumConfigurations"
            1 (64 bytes) <CFString 0x145f09860> [64]  length: 17  "kUSBProductString"
            1 (64 bytes) <CFString 0x145f098d0> [64]  length: 16  "kUSBVendorString"
            1 (64 bytes) <CFString 0x145f09940> [64]  length: 15  "kUSBContainerID"
            1 (64 bytes) <CFString 0x145f099d0> [64]  length: 18  "UsbDeviceSignature"
            1 (64 bytes) <CFString 0x145f09aa0> [64]  length: 25  "IOServiceDEXTEntitlements"
            1 (64 bytes) <CFString 0x145f09da0> [64]  length: 24  "kUSBCurrentConfiguration"
            1 (48 bytes) <CFString 0x145f09150> [48]  length: 12  "Device Speed"
            1 (48 bytes) <CFString 0x145f09180> [48]  length: 11  "USB Address"
            1 (48 bytes) <CFString 0x145f09720> [48]  length: 11  "USBPortType"
            1 (48 bytes) <CFString 0x145f09750> [48]  length: 11  "kUSBAddress"
            1 (48 bytes) <CFString 0x145f097c0> [48]  length: 13  "iManufacturer"
            1 (48 bytes) <CFString 0x145f097f0> [48]  length: 13  "iSerialNumber"
            1 (48 bytes) <CFString 0x145f098a0> [48]  length: 10  "USB3.1 Hub"
            1 (48 bytes) <CFString 0x145f09910> [48]  length: 12  "GenesysLogic"
            1 (48 bytes) <CFString 0x145f09d70> [48]  length: 13  "AppleUSB30Hub"

      42 (3.22K) ROOT LEAK: <NSMutableDictionary 0x145f09310> [48]  item count: 31
         41 (3.17K) <NSMutableDictionary (Storage) 0x145f09de0> [672]
            7 (576 bytes) <NSMutableDictionary 0x145f09340> [48]  item count: 7
               6 (528 bytes) <NSMutableDictionary (Storage) 0x145f0a290> [224]
                  1 (64 bytes) <CFString 0x145f094c0> [64]  length: 16  "DevicePowerState"
                  1 (64 bytes) <CFString 0x145f0a580> [64]  length: 16  "DriverPowerState"
                  1 (64 bytes) <CFString 0x145f0a5c0> [64]  length: 15  "CapabilityFlags"
                  1 (64 bytes) <CFString 0x145f0a630> [64]  length: 15  "PowerOverrideOn"
                  1 (48 bytes) <CFString 0x145f0a600> [48]  length: 13  "MaxPowerState"
            4 (288 bytes) <NSMutableDictionary 0x145f0ab80> [48]  item count: 1
               3 (240 bytes) <NSMutableDictionary (Storage) 0x145f0abb0> [64]
                  1 (96 bytes) <CFString 0x145f0a0d0> [96]  length: 53  "IOUSBHostFamily.kext/Contents/PlugIns/IOUSBLib.bundle"
                  1 (80 bytes) <CFString 0x145f0a080> [80]  length: 36  "9dc7b780-9ec0-11d4-a54f-000a27052861"
            5 (272 bytes) <NSMutableArray 0x145f0aab0> [64]  item count: 1
               4 (208 bytes) <NSMutableArray (Storage) 0x145f09500> [32]
                  3 (176 bytes) <NSMutableArray 0x145f0aaf0> [64]  item count: 1
                     2 (112 bytes) <NSMutableArray (Storage) 0x145f08120> [32]
                        1 (80 bytes) <CFString 0x145f0ab30> [80]  length: 43  "com.apple.developer.driverkit.transport.usb"
            1 (96 bytes) <CFData 0x145f0aa10> [96]  inline content length 12: 0xE30510065606090001090000
            1 (80 bytes) <CFString 0x145f0a980> [80]  length: 36  "f0564b9f-f61d-e011-ac64-0800200c9a66"
            1 (64 bytes) <CFString 0x145f0a130> [64]  length: 16  "USB Product Name"
            1 (64 bytes) <CFString 0x145f0a170> [64]  length: 15  "USB Vendor Name"
            1 (64 bytes) <CFString 0x145f0a210> [64]  length: 17  "UsbExclusiveOwner"
            1 (64 bytes) <CFString 0x145f0a6a0> [64]  length: 15  "bDeviceSubClass"
            1 (64 bytes) <CFString 0x145f0a6e0> [64]  length: 15  "bDeviceProtocol"
            1 (64 bytes) <CFString 0x145f0a780> [64]  length: 15  "bMaxPacketSize0"
            1 (64 bytes) <CFString 0x145f0a820> [64]  length: 18  "bNumConfigurations"
            1 (64 bytes) <CFString 0x145f0a860> [64]  length: 17  "kUSBProductString"
            1 (64 bytes) <CFString 0x145f0a8d0> [64]  length: 16  "kUSBVendorString"
            1 (64 bytes) <CFString 0x145f0a940> [64]  length: 15  "kUSBContainerID"
            1 (64 bytes) <CFString 0x145f0a9d0> [64]  length: 18  "UsbDeviceSignature"
            1 (64 bytes) <CFString 0x145f0aa70> [64]  length: 25  "IOServiceDEXTEntitlements"
            1 (64 bytes) <CFString 0x145f0abf0> [64]  length: 24  "kUSBCurrentConfiguration"
            1 (48 bytes) <CFString 0x145f0a1b0> [48]  length: 12  "Device Speed"
            1 (48 bytes) <CFString 0x145f0a1e0> [48]  length: 11  "USB Address"
            1 (48 bytes) <CFString 0x145f0a250> [48]  length: 13  "AppleUSB20Hub"
            1 (48 bytes) <CFString 0x145f0a720> [48]  length: 11  "USBPortType"
            1 (48 bytes) <CFString 0x145f0a750> [48]  length: 11  "kUSBAddress"
            1 (48 bytes) <CFString 0x145f0a7c0> [48]  length: 13  "iManufacturer"
            1 (48 bytes) <CFString 0x145f0a7f0> [48]  length: 13  "iSerialNumber"
            1 (48 bytes) <CFString 0x145f0a8a0> [48]  length: 10  "USB2.1 Hub"
            1 (48 bytes) <CFString 0x145f0a910> [48]  length: 12  "GenesysLogic"

      40 (3.12K) ROOT LEAK: <NSMutableDictionary 0x145f0a370> [48]  item count: 31
         39 (3.08K) <NSMutableDictionary (Storage) 0x145f0ac30> [672]
            7 (576 bytes) <NSMutableDictionary 0x145f0a3a0> [48]  item count: 7
               6 (528 bytes) <NSMutableDictionary (Storage) 0x145f0a3d0> [224]
                  1 (64 bytes) <CFString 0x145f0a4b0> [64]  length: 16  "DevicePowerState"
                  1 (64 bytes) <CFString 0x145f0a4f0> [64]  length: 16  "DriverPowerState"
                  1 (64 bytes) <CFString 0x145f0a530> [64]  length: 15  "CapabilityFlags"
                  1 (64 bytes) <CFString 0x145f0b320> [64]  length: 15  "PowerOverrideOn"
                  1 (48 bytes) <CFString 0x145f0b2f0> [48]  length: 13  "MaxPowerState"
            4 (288 bytes) <NSMutableDictionary 0x145f0b810> [48]  item count: 1
               3 (240 bytes) <NSMutableDictionary (Storage) 0x145f0b840> [64]
                  1 (96 bytes) <CFString 0x145f0af20> [96]  length: 53  "IOUSBHostFamily.kext/Contents/PlugIns/IOUSBLib.bundle"
                  1 (80 bytes) <CFString 0x145f0aed0> [80]  length: 36  "9dc7b780-9ec0-11d4-a54f-000a27052861"
            5 (272 bytes) <NSMutableArray 0x145f0b740> [64]  item count: 1
               4 (208 bytes) <NSMutableArray (Storage) 0x145f07f10> [32]
                  3 (176 bytes) <NSMutableArray 0x145f0b780> [64]  item count: 1
                     2 (112 bytes) <NSMutableArray (Storage) 0x145f07ea0> [32]
                        1 (80 bytes) <CFString 0x145f0b7c0> [80]  length: 43  "com.apple.developer.driverkit.transport.usb"
            1 (112 bytes) <CFData 0x145f0b690> [112]  inline content length 27: 0x6D0492C000 "R207036595943" 0x0000030102030000
            1 (64 bytes) <CFString 0x145f0af80> [64]  length: 16  "USB Product Name"
            1 (64 bytes) <CFString 0x145f0afc0> [64]  length: 15  "USB Vendor Name"
            1 (64 bytes) <CFString 0x145f0b000> [64]  length: 17  "USB Serial Number"
            1 (64 bytes) <CFString 0x145f0b0a0> [64]  length: 24  "kUSBCurrentConfiguration"
            1 (64 bytes) <CFString 0x145f0b360> [64]  length: 15  "bDeviceSubClass"
            1 (64 bytes) <CFString 0x145f0b3a0> [64]  length: 15  "bDeviceProtocol"
            1 (64 bytes) <CFString 0x145f0b440> [64]  length: 15  "bMaxPacketSize0"
            1 (64 bytes) <CFString 0x145f0b4e0> [64]  length: 18  "bNumConfigurations"
            1 (64 bytes) <CFString 0x145f0b520> [64]  length: 17  "kUSBProductString"
            1 (64 bytes) <CFString 0x145f0b560> [64]  length: 27  "G102 LIGHTSYNC Gaming Mouse"
            1 (64 bytes) <CFString 0x145f0b5a0> [64]  length: 16  "kUSBVendorString"
            1 (64 bytes) <CFString 0x145f0b5e0> [64]  length: 22  "kUSBSerialNumberString"
            1 (64 bytes) <CFString 0x145f0b650> [64]  length: 18  "UsbDeviceSignature"
            1 (64 bytes) <CFString 0x145f0b700> [64]  length: 25  "IOServiceDEXTEntitlements"
            1 (48 bytes) <CFString 0x145f0b040> [48]  length: 12  "Device Speed"
            1 (48 bytes) <CFString 0x145f0b070> [48]  length: 11  "USB Address"
            1 (48 bytes) <CFString 0x145f0b3e0> [48]  length: 11  "USBPortType"
            1 (48 bytes) <CFString 0x145f0b410> [48]  length: 11  "kUSBAddress"
            1 (48 bytes) <CFString 0x145f0b480> [48]  length: 13  "iManufacturer"
            1 (48 bytes) <CFString 0x145f0b4b0> [48]  length: 13  "iSerialNumber"
            1 (48 bytes) <CFString 0x145f0b620> [48]  length: 12  "207036595943"

      37 (2.92K) ROOT LEAK: <NSMutableDictionary 0x145f0b0e0> [48]  item count: 29
         36 (2.88K) <NSMutableDictionary (Storage) 0x145f0b880> [672]
            7 (576 bytes) <NSMutableDictionary 0x145f0b140> [48]  item count: 7
               6 (528 bytes) <NSMutableDictionary (Storage) 0x145f0b170> [224]
                  1 (64 bytes) <CFString 0x145f0b250> [64]  length: 16  "DevicePowerState"
                  1 (64 bytes) <CFString 0x145f0b290> [64]  length: 16  "DriverPowerState"
                  1 (64 bytes) <CFString 0x145f0bf40> [64]  length: 15  "CapabilityFlags"
                  1 (64 bytes) <CFString 0x145f0bfb0> [64]  length: 15  "PowerOverrideOn"
                  1 (48 bytes) <CFString 0x145f0bf80> [48]  length: 13  "MaxPowerState"
            4 (288 bytes) <NSMutableDictionary 0x145f0c410> [48]  item count: 1
               3 (240 bytes) <NSMutableDictionary (Storage) 0x145f0c440> [64]
                  1 (96 bytes) <CFString 0x145f0c4d0> [96]  length: 53  "IOUSBHostFamily.kext/Contents/PlugIns/IOUSBLib.bundle"
                  1 (80 bytes) <CFString 0x145f0c480> [80]  length: 36  "9dc7b780-9ec0-11d4-a54f-000a27052861"
            5 (272 bytes) <NSMutableArray 0x145f0c340> [64]  item count: 1
               4 (208 bytes) <NSMutableArray (Storage) 0x145f0b2d0> [32]
                  3 (176 bytes) <NSMutableArray 0x145f0c380> [64]  item count: 1
                     2 (112 bytes) <NSMutableArray (Storage) 0x145f07510> [32]
                        1 (80 bytes) <CFString 0x145f0c3c0> [80]  length: 43  "com.apple.developer.driverkit.transport.usb"
            1 (96 bytes) <CFData 0x145f0c2a0> [96]  inline content length 15: 0x0F3200500501000000030101030102
            1 (64 bytes) <CFString 0x145f0bb20> [64]  length: 16  "USB Product Name"
            1 (64 bytes) <CFString 0x145f0bb60> [64]  length: 15  "USB Vendor Name"
            1 (64 bytes) <CFString 0x145f0bc00> [64]  length: 24  "kUSBCurrentConfiguration"
            1 (64 bytes) <CFString 0x145f0bff0> [64]  length: 15  "bDeviceSubClass"
            1 (64 bytes) <CFString 0x145f0c030> [64]  length: 15  "bDeviceProtocol"
            1 (64 bytes) <CFString 0x145f0c0d0> [64]  length: 15  "bMaxPacketSize0"
            1 (64 bytes) <CFString 0x145f0c170> [64]  length: 18  "bNumConfigurations"
            1 (64 bytes) <CFString 0x145f0c1b0> [64]  length: 17  "kUSBProductString"
            1 (64 bytes) <CFString 0x145f0c220> [64]  length: 16  "kUSBVendorString"
            1 (64 bytes) <CFString 0x145f0c260> [64]  length: 18  "UsbDeviceSignature"
            1 (64 bytes) <CFString 0x145f0c300> [64]  length: 25  "IOServiceDEXTEntitlements"
            1 (48 bytes) <CFString 0x145f0bba0> [48]  length: 12  "Device Speed"
            1 (48 bytes) <CFString 0x145f0bbd0> [48]  length: 11  "USB Address"
            1 (48 bytes) <CFString 0x145f0c070> [48]  length: 11  "USBPortType"
            1 (48 bytes) <CFString 0x145f0c0a0> [48]  length: 11  "kUSBAddress"
            1 (48 bytes) <CFString 0x145f0c110> [48]  length: 13  "iManufacturer"
            1 (48 bytes) <CFString 0x145f0c140> [48]  length: 13  "iSerialNumber"
            1 (48 bytes) <CFString 0x145f0c1f0> [48]  length: 12  "RGB Keyboard"
```

cc @timfish 
