### PR TITLE
Make 1.50.0 the MSRV

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,7 +7,7 @@ jobs:
     strategy:
       matrix:
         os: [windows-latest, macos-latest, ubuntu-latest]
-        rust: [1.36.0, stable, beta, nightly]
+        rust: [1.50.0, stable, beta, nightly]
       fail-fast: false
 
     steps:


### PR DESCRIPTION
Since Github Actions now uses arm64 for macOS...